### PR TITLE
Update recommended filename function to provide a complete path

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import pytest
 from utils import (
     MediaType,
     datestamp_to_filename_stem,
+    datestamp_to_folder,
     datestring_to_date,
     get_datestamp,
     get_media_type,
@@ -75,10 +76,23 @@ def test_datestamp_to_filenam_stem():
     )
 
 
+def test_datestamp_to_folder():
+    assert datestamp_to_folder(datetime.strptime("2021-06-12 09:14:20", "%Y-%m-%d %H:%M:%S")) == "2021/06/12"
+
+
 def test_get_recommended_filename():
     assert get_recommended_filename(DATA_DIR.joinpath("Rose/20210612_091420_cap_extension.JPG")) == DATA_DIR.joinpath(
         "Rose/20210612_091420.jpg"
     )
+    assert get_recommended_filename(
+        DATA_DIR.joinpath("Rose/20210612_091420_cap_extension.JPG"), date_folders=True
+    ) == DATA_DIR.joinpath("Rose/2021/06/12/20210612_091420.jpg")
+    assert get_recommended_filename(
+        DATA_DIR.joinpath("Rose/20210612_091420_cap_extension.JPG"), root_dir=Path("/dingo")
+    ) == Path("/dingo/20210612_091420.jpg")
+    assert get_recommended_filename(
+        DATA_DIR.joinpath("Rose/20210612_091420_cap_extension.JPG"), root_dir=Path("/dingo"), date_folders=True
+    ) == Path("/dingo/2021/06/12/20210612_091420.jpg")
     assert get_recommended_filename(Path("/path/does/not/exist.txt")) is None
 
 

--- a/utils.py
+++ b/utils.py
@@ -134,11 +134,41 @@ def get_datestamp(image_path: Path):
     return date_obj
 
 
-def datestamp_to_filename_stem(date_obj: datetime):
+def datestamp_to_filename_stem(date_obj: datetime) -> str:
+    """Datestampe to filname stem
+
+    Args:
+        date_obj (datetime): A datetime object
+
+    Returns:
+        str: The string representation of a new filename without extension.
+    """
     return date_obj.strftime("%Y%m%d_%H%M%S")
 
 
-def get_recommended_filename(image_path: Path):
+def datestamp_to_folder(date_obj: datetime) -> str:
+    """Datestamp to folder
+
+    Args:
+        date_obj (datetime): A datetime object
+
+    Returns:
+        str: The string representation of a folder structure in the format 'YYYY/MM/DD'
+    """
+    return date_obj.strftime("%Y/%m/%d")
+
+
+def get_recommended_filename(image_path: Path, date_folders=False, root_dir=None) -> Path:
+    """Provide a recommended filename for an image.
+
+    Args:
+        image_path (Path): The path of an image file
+        date_folders (bool, optional): Whether to prefix the recommended filename with recommended folders. Defaults to False.
+        root_dir (_type_, optional): The path of a directory to use instead of the file's current directory. Defaults to None.
+
+    Returns:
+        Path: The complete path to the recommended filename
+    """
     image_type = guess_type(image_path)[0]
     if image_type.endswith("jpeg"):
         new_extension = "jpg"
@@ -151,8 +181,12 @@ def get_recommended_filename(image_path: Path):
     if not datestamp_from_image:
         return None
 
+    parent_directory = root_dir if root_dir else image_path.parent
+
+    if date_folders:
+        parent_directory = parent_directory.joinpath(datestamp_to_folder(datestamp_from_image))
+
     new_stem = datestamp_to_filename_stem(datestamp_from_image)
-    parent_directory = image_path.parent
 
     new_filename = parent_directory.joinpath(f"{new_stem}.{new_extension}")
     return new_filename

--- a/utils.py
+++ b/utils.py
@@ -158,13 +158,13 @@ def datestamp_to_folder(date_obj: datetime) -> str:
     return date_obj.strftime("%Y/%m/%d")
 
 
-def get_recommended_filename(image_path: Path, date_folders=False, root_dir=None) -> Path:
+def get_recommended_filename(image_path: Path, date_folders: bool = False, root_dir: Path = None) -> Path:
     """Provide a recommended filename for an image.
 
     Args:
         image_path (Path): The path of an image file
         date_folders (bool, optional): Whether to prefix the recommended filename with recommended folders. Defaults to False.
-        root_dir (_type_, optional): The path of a directory to use instead of the file's current directory. Defaults to None.
+        root_dir (Path, optional): The path of a directory to use instead of the file's current directory. Defaults to None.
 
     Returns:
         Path: The complete path to the recommended filename


### PR DESCRIPTION
Updated the recommended filename function. You can now pass in a different root directory than the parent directory. You can also specify whether the recommended filename should be prefixed with date-based folder structure.